### PR TITLE
Add "lazy" version of `maybe`

### DIFF
--- a/docs/Data/Maybe.md
+++ b/docs/Data/Maybe.md
@@ -55,6 +55,22 @@ maybe x f Nothing == x
 maybe x f (Just y) == f y
 ```
 
+#### `maybe'`
+
+``` purescript
+maybe' :: forall a b. (Unit -> b) -> (a -> b) -> Maybe a -> b
+```
+
+Similar to `maybe` but for use in cases where the default value may be
+expensive to compute. As PureScript is not lazy, the standard `maybe` has
+to evaluate the default value before returning the result, whereas here
+the value is only computed when the `Maybe` is known to be `Nothing`.
+
+``` purescript
+maybe' (\_ -> x) f Nothing == x
+maybe' (\_ -> x) f (Just y) == f y
+```
+
 #### `fromMaybe`
 
 ``` purescript
@@ -68,6 +84,22 @@ Takes a default value, and a `Maybe` value. If the `Maybe` value is
 ``` purescript
 fromMaybe x Nothing == x
 fromMaybe x (Just y) == y
+```
+
+#### `fromMaybe'`
+
+``` purescript
+fromMaybe' :: forall a. (Unit -> a) -> Maybe a -> a
+```
+
+Similar to `fromMaybe` but for use in cases where the default value may be
+expensive to compute. As PureScript is not lazy, the standard `fromMaybe`
+has to evaluate the default value before returning the result, whereas here
+the value is only computed when the `Maybe` is known to be `Nothing`.
+
+``` purescript
+fromMaybe' (\_ -> x) Nothing == x
+fromMaybe' (\_ -> x) (Just y) == y
 ```
 
 #### `isJust`

--- a/src/Data/Maybe.purs
+++ b/src/Data/Maybe.purs
@@ -27,6 +27,19 @@ maybe :: forall a b. b -> (a -> b) -> Maybe a -> b
 maybe b _ Nothing = b
 maybe _ f (Just a) = f a
 
+-- | Similar to `maybe` but for use in cases where the default value may be
+-- | expensive to compute. As PureScript is not lazy, the standard `maybe` has
+-- | to evaluate the default value before returning the result, whereas here
+-- | the value is only computed when the `Maybe` is known to be `Nothing`.
+-- |
+-- | ``` purescript
+-- | maybe' (\_ -> x) f Nothing == x
+-- | maybe' (\_ -> x) f (Just y) == f y
+-- | ```
+maybe' :: forall a b. (Unit -> b) -> (a -> b) -> Maybe a -> b
+maybe' g _ Nothing = g unit
+maybe' _ f (Just a) = f a
+
 -- | Takes a default value, and a `Maybe` value. If the `Maybe` value is
 -- | `Nothing` the default value is returned, otherwise the value inside the
 -- | `Just` is returned.
@@ -37,6 +50,18 @@ maybe _ f (Just a) = f a
 -- | ```
 fromMaybe :: forall a. a -> Maybe a -> a
 fromMaybe a = maybe a (id :: forall a. a -> a)
+
+-- | Similar to `fromMaybe` but for use in cases where the default value may be
+-- | expensive to compute. As PureScript is not lazy, the standard `fromMaybe`
+-- | has to evaluate the default value before returning the result, whereas here
+-- | the value is only computed when the `Maybe` is known to be `Nothing`.
+-- |
+-- | ``` purescript
+-- | fromMaybe' (\_ -> x) Nothing == x
+-- | fromMaybe' (\_ -> x) (Just y) == y
+-- | ```
+fromMaybe' :: forall a. (Unit -> a) -> Maybe a -> a
+fromMaybe' a = maybe' a (id :: forall a. a -> a)
 
 -- | Returns `true` when the `Maybe` value was constructed with `Just`.
 isJust :: forall a. Maybe a -> Boolean


### PR DESCRIPTION
For discussion first, I'll add comments if we're ok with this.

Basically, this thunks the alternative value, so if you don't want to resort to writing a case explicitly you can still use `maybe`-style folds in cases where it might be expensive to do so.