### PR TITLE
Remove explicit type annotations for `id`

### DIFF
--- a/src/Data/Maybe.purs
+++ b/src/Data/Maybe.purs
@@ -49,7 +49,7 @@ maybe' _ f (Just a) = f a
 -- | fromMaybe x (Just y) == y
 -- | ```
 fromMaybe :: forall a. a -> Maybe a -> a
-fromMaybe a = maybe a (id :: forall a. a -> a)
+fromMaybe a = maybe a id
 
 -- | Similar to `fromMaybe` but for use in cases where the default value may be
 -- | expensive to compute. As PureScript is not lazy, the standard `fromMaybe`
@@ -61,7 +61,7 @@ fromMaybe a = maybe a (id :: forall a. a -> a)
 -- | fromMaybe' (\_ -> x) (Just y) == y
 -- | ```
 fromMaybe' :: forall a. (Unit -> a) -> Maybe a -> a
-fromMaybe' a = maybe' a (id :: forall a. a -> a)
+fromMaybe' a = maybe' a id
 
 -- | Returns `true` when the `Maybe` value was constructed with `Just`.
 isJust :: forall a. Maybe a -> Boolean


### PR DESCRIPTION
Don't seem to be needed anymore + `forall a.` was triggering "shadowed type variable" warnings.