### PR TITLE
Added whenJust

### DIFF
--- a/src/Data/Maybe.purs
+++ b/src/Data/Maybe.purs
@@ -263,3 +263,8 @@ isNothing = maybe true (const false)
 -- | runtime.
 fromJust :: forall a. Partial => Maybe a -> a
 fromJust (Just x) = x
+
+-- | Allows to unpack `Maybe` value, and use it immediately
+whenJust :: forall m a. Applicative m => Maybe a -> (a -> m Unit) -> m Unit
+whenJust Nothing  _ = pure unit
+whenJust (Just v) f = f    v


### PR DESCRIPTION
Hi,

`whenJust` is useful shorthand for checking that value is `Just` something and unpacking it for use within a `Monad`.