### PR TITLE
fixed documentation error in the Extend typeclass

### DIFF
--- a/src/Data/Maybe.purs
+++ b/src/Data/Maybe.purs
@@ -153,7 +153,7 @@ instance monadZeroMaybe :: MonadZero Maybe
 -- |
 -- | ``` purescript
 -- | f <<= Nothing = Nothing
--- | f <<= Just x = Just (f x)
+-- | f <<= x = Just (f x)
 -- | ```
 instance extendMaybe :: Extend Maybe where
   extend _ Nothing  = Nothing


### PR DESCRIPTION
As it's currently written it sounds like `extend = map` but this isn't the case.