### PR TITLE
Remove mention of `return` function

### DIFF
--- a/src/Data/Maybe.purs
+++ b/src/Data/Maybe.purs
@@ -69,11 +69,10 @@ instance applyMaybe :: Apply Maybe where
   apply Nothing   _ = Nothing
 
 -- | The `Applicative` instance enables lifting of values into `Maybe` with the
--- | `pure` or `return` function (`return` is an alias for `pure`):
+-- | `pure` function:
 -- |
 -- | ``` purescript
 -- | pure x :: Maybe _ == Just x
--- | return x :: Maybe _ == Just x
 -- | ```
 -- |
 -- | Combining `Functor`'s `<$>` with `Apply`'s `<*>` and `Applicative`'s


### PR DESCRIPTION
I don’t think `return` is part of the library anymore: I couldn’t find it on Pursuit nor did it work in PSCi (0.12). Please ignore if I got this wrong 😉 