### PR TITLE
Add Semiring instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `Semiring` instance (#59)
 
 Bugfixes:
 

--- a/src/Data/Maybe.purs
+++ b/src/Data/Maybe.purs
@@ -190,6 +190,16 @@ instance semigroupMaybe :: Semigroup a => Semigroup (Maybe a) where
 instance monoidMaybe :: Semigroup a => Monoid (Maybe a) where
   mempty = Nothing
 
+instance semiringMaybe :: Semiring a => Semiring (Maybe a) where
+  zero = Nothing
+  one = Just one
+
+  add Nothing y = y
+  add x Nothing = x
+  add (Just x) (Just y) = Just (add x y)
+
+  mul x y = mul <$> x <*> y
+
 -- | The `Eq` instance allows `Maybe` values to be checked for equality with
 -- | `==` and inequality with `/=` whenever there is an `Eq` instance for the
 -- | type the `Maybe` contains.


### PR DESCRIPTION
**Description of the change**

`Semiring` instance was removed by #20 with response to #18, due to it not satisfying all the semiring laws. This PR re-adds the instance with an implementation that satisfies the laws. The instance passed all the tests provided by [`Test.QuickCheck.Laws.Data.Semiring`](https://pursuit.purescript.org/packages/purescript-quickcheck-laws/6.0.1/docs/Test.QuickCheck.Laws.Data.Semiring). The implementation is roughly the same as the instance from the [`semirings`](https://hackage.haskell.org/package/semirings-0.6) package on Hackage.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
